### PR TITLE
request pull of code to swap low-level left/right cmd/alt bits as well in event flag

### DIFF
--- a/cmd-key-happy.m
+++ b/cmd-key-happy.m
@@ -38,6 +38,7 @@
 #import <Foundation/Foundation.h>
 #import <AppKit/AppKit.h>
 #import <Carbon/Carbon.h>
+#import <IOKit/hidsystem/IOLLEvent.h>
 
 #include <lua.h>
 #include <lauxlib.h>
@@ -395,9 +396,25 @@ static CGEventRef handleEvent(CGEventTapProxy proxy, CGEventType type,
 	if (flags & kCGEventFlagMaskCommand) {
 	    flags &= ~kCGEventFlagMaskCommand;
 	    flags |= kCGEventFlagMaskAlternate;
+	    if (flags & NX_DEVICELCMDKEYMASK) {
+		flags &= ~NX_DEVICELCMDKEYMASK;
+		flags |= NX_DEVICELALTKEYMASK;
+	    }
+	    if (flags & NX_DEVICERCMDKEYMASK) {
+		flags &= ~NX_DEVICERCMDKEYMASK;
+		flags |= NX_DEVICERALTKEYMASK;
+	    }
 	} else if (flags & kCGEventFlagMaskAlternate) {
 	    flags &= ~kCGEventFlagMaskAlternate;
 	    flags |= kCGEventFlagMaskCommand;
+	    if (flags & NX_DEVICELALTKEYMASK) {
+		flags &= ~NX_DEVICELALTKEYMASK;
+		flags |= NX_DEVICELCMDKEYMASK;
+	    }
+	    if (flags & NX_DEVICERALTKEYMASK) {
+		flags &= ~NX_DEVICERALTKEYMASK;
+		flags |= NX_DEVICERCMDKEYMASK;
+	    }
 	}
 	CGEventSetFlags(event, flags);
     }


### PR DESCRIPTION
Thanks so much for cmd-key-happy! It's been working great for me and several of my coworkers for months. The current head of iTerm2 has new code that uses the low-level (and low-order) flag bits of key events to distinguish left and right option keys for possible separate treatment. cmd-key-happy doesn't currently swap those flags. I made a change to do that swapping in my fork and that restored good cooperation between cmd-key-happy and iTerm2. Please consider pulling this change into your repo.
